### PR TITLE
Add prod link for password reset URL

### DIFF
--- a/src/utils/email.js
+++ b/src/utils/email.js
@@ -10,19 +10,13 @@ const templateIds = {
   passwordReset: "d-3cedb1dc419944c2bb960e8782a17681",
   passwordResetConfirmation: "d-a011458f2d274526a23236091daa7372",
 };
-const passwordResetBaseUrl = "https://dcia.herokuapp.com/reset_password";
 
 function capitalize(str) {
   return str.charAt(0).toUpperCase() + str.slice(1);
 }
 
 function createResetUrl(token) {
-  const localPasswordResetUrl = "http://localhost:3000/reset_password";
-  if (process.env.NODE_ENV === "production") {
-    return encodeURI(passwordResetBaseUrl + "/?token=" + token);
-  } else {
-    return encodeURI(localPasswordResetUrl + "/?token=" + token);
-  }
+  return encodeURI(`${process.env.APP_URL}/reset_password?token=${token}`);
 }
 
 export async function getLocationData(ipAddress) {


### PR DESCRIPTION
I updated all the Sendgrid templates to use the https://dcia.herokuapp.com link in the email signatures, which didn't include any code changes.

This PR is just to update the password reset link builder. If the environment is prod, use the link above as the base URL, otherwise use localhost.

Closes #41 