### PR TITLE
Run Cypress against production mode server 🔥

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -28,7 +28,8 @@ jobs:
       - name: Cypress run
         uses: cypress-io/github-action@v2
         with:
-          start: npm run dev
+          build: npm run build
+          start: npm run start
           wait-on: "http://localhost:3000"
         env:
           NEXTAUTH_URL: http://localhost:3000

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -41,3 +41,14 @@ jobs:
         env:
           NEXTAUTH_URL: http://localhost:3000
           MONGO_URL: mongodb://localhost:27017/dcia
+
+      - uses: actions/upload-artifact@v1
+        if: failure()
+        with:
+          name: cypress-screenshots
+          path: cypress/screenshots
+      - uses: actions/upload-artifact@v1
+        if: always()
+        with:
+          name: cypress-videos
+          path: cypress/videos

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -18,6 +18,13 @@ jobs:
         with:
           mongodb-version: "4.4"
 
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cache
+            ~/.npm
+          key: v1-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
+
       - run: npm ci
 
       - name: Seed the Database

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "start": "next start -p $PORT",
+    "start": "next start -p ${PORT:-3000}",
     "lint": "eslint \"src/**/*.{js,jsx}\" --quiet",
     "e2e": "start-test dev 3000 cy:open",
     "cy:open": "cypress open",

--- a/src/middleware/database.js
+++ b/src/middleware/database.js
@@ -6,7 +6,7 @@ const client = mongoose.connect(process.env.MONGO_URL, {
   useCreateIndex: true,
   useFindAndModify: false,
 });
-if (process.env.NODE_ENV !== "production") {
+if (process.env.NODE_ENV === "development") {
   mongoose.set("debug", true);
 }
 

--- a/src/utils/db.js
+++ b/src/utils/db.js
@@ -1,7 +1,7 @@
 import mongoose from "mongoose";
 
 export const connect = () => {
-  if (process.env.NODE_ENV !== "production") {
+  if (process.env.NODE_ENV === "development") {
     mongoose.set("debug", true);
   }
   mongoose.connect(process.env.MONGO_URL, {

--- a/src/utils/email.js
+++ b/src/utils/email.js
@@ -21,10 +21,15 @@ function createResetUrl(token) {
   return encodeURI(`${process.env.APP_URL}/reset_password?token=${token}`);
 }
 
+function isEmailEnabled() {
+  const enabledServices = process.env.ENABLED_SERVICES || "";
+  return enabledServices.split(",").includes("email");
+}
+
 export async function getLocationData(ipAddress) {
   const url = `${process.env.IP_API_ENDPOINT}/${ipAddress}?access_key=${process.env.IP_API_KEY}`;
   try {
-    if (process.env.NODE_ENV !== "production") {
+    if (!isEmailEnabled()) {
       return Promise.resolve("Localhost, USA 🇺🇸");
     }
 
@@ -62,11 +67,11 @@ async function sendEmail(msgContents, emailType) {
   return new Promise((resolve, reject) => {
     try {
       // Don't send emails in test/development
-      if (process.env.NODE_ENV !== "production") {
+      if (isEmailEnabled()) {
+        sendGrid.send(msgContents);
+      } else {
         console.log(`${emailType} EMAIL: `);
         console.log(msgContents);
-      } else {
-        sendGrid.send(msgContents);
       }
       resolve("Email(s) sent!");
     } catch (err) {


### PR DESCRIPTION
This change drops the CI time for end-to-end tests from ~5m to ~3m.

Most of that speedup was from changing the NextJS server to run against the production build (`npm run build` / `npm run start`) instead of the development server (`npm run dev`). However, to do this I had to shuffle around some of the email configs since the built version is hard-coded to the "production" env. I added a new variable `ENABLED_SERVICES` that we can set to `"email"` for production; that way we can test the production build *without* actually sending emails.