### PR TITLE
Add Course Detail Page

### DIFF
--- a/src/components/CourseInstancesCard.jsx
+++ b/src/components/CourseInstancesCard.jsx
@@ -1,0 +1,44 @@
+import EmptyItem from "components/EmptyItem.jsx";
+import Link from "next/link";
+import { Card, ListGroup } from "react-bootstrap";
+import useSWR from "swr";
+import fetcher from "utils/fetcher";
+import { capitalize } from "utils/string";
+
+export default function CourseInstanceCard({ course }) {
+  return (
+    <Card className="mt-3">
+      <Card.Header className="bg-white">Course Instances</Card.Header>
+      <ListGroup variant="flush">
+        <CourseInstanceItems course={course} />
+      </ListGroup>
+    </Card>
+  );
+}
+
+function CourseInstanceItems({ course }) {
+  const { data, error } = useSWR(
+    `/api/course-instances?course=${course._id}`,
+    fetcher
+  );
+
+  if (error) return <EmptyItem message="Failed to load." />;
+  if (!data) return <EmptyItem message={<em>Loading...</em>} />;
+  if (data.length === 0) {
+    return <EmptyItem message="No course instances found." />;
+  }
+
+  return data.map(({ _id, semester, instructor: { name: instructorName } }) => (
+    <ListGroup.Item
+      className="d-flex justify-content-between align-items-center"
+      key={_id}
+    >
+      <Link href={`/courses/${course._id}`}>
+        {`${capitalize(semester.term)} ${semester.year}`}
+      </Link>
+      <span className="badge badge-secondary badge-pill">
+        {instructorName.first} {instructorName.last}
+      </span>
+    </ListGroup.Item>
+  ));
+}

--- a/src/components/CoursesCard.jsx
+++ b/src/components/CoursesCard.jsx
@@ -1,10 +1,11 @@
-import EmptyRow from "components/EmptyRow.jsx";
 import CourseFormModal from "components/CourseFormModal.jsx";
+import EmptyRow from "components/EmptyRow.jsx";
+import { useSession } from "next-auth/client";
+import Link from "next/link";
 import { useState } from "react";
 import { Button, Card, OverlayTrigger, Table, Tooltip } from "react-bootstrap";
 import useSWR, { mutate } from "swr";
 import fetcher from "utils/fetcher";
-import { useSession } from "next-auth/client";
 
 const COURSES_PATH = "/api/courses";
 
@@ -41,8 +42,10 @@ function CourseRow({ course }) {
   const [session] = useSession();
   return (
     <tr>
-      <td>{course.number}</td>
-      <td>{course.title}</td>
+      <td>CPSC {course.number}</td>
+      <td>
+        <Link href={`/courses/${course._id}`}>{course.title}</Link>
+      </td>
       <td className="pb-0">
         <StudentOutcomes studentOutcomes={course.studentOutcomes} />
       </td>

--- a/src/components/EmptyItem.jsx
+++ b/src/components/EmptyItem.jsx
@@ -1,0 +1,9 @@
+import { ListGroup } from "react-bootstrap";
+
+export default function EmptyItem({ message }) {
+  return (
+    <ListGroup.Item className="d-flex justify-content-between align-items-center text-muted">
+      {message}
+    </ListGroup.Item>
+  );
+}

--- a/src/models/StudentOutcome.js
+++ b/src/models/StudentOutcome.js
@@ -17,5 +17,5 @@ const studentOutcomeSchema = new mongoose.Schema(
   { timestamps: true }
 );
 
-export default mongoose.models.StudentOutcome ||
+export default mongoose.models?.StudentOutcome ||
   mongoose.model("StudentOutcome", studentOutcomeSchema);

--- a/src/pages/api/course-instances.js
+++ b/src/pages/api/course-instances.js
@@ -1,0 +1,24 @@
+import middleware from "middleware";
+import CourseInstance from "models/CourseInstance";
+import "models/Semester";
+import "models/Instructor";
+import nextConnect from "next-connect";
+import { authenticate } from "utils/auth";
+
+const handler = nextConnect();
+handler.use(middleware);
+handler.use(authenticate);
+
+handler.get(async (req, res) => {
+  const {
+    query: { course },
+  } = req;
+
+  const courseInstances = await CourseInstance.find({ course })
+    .populate("semester", "year term")
+    .populate("instructor", "name");
+
+  res.json(courseInstances);
+});
+
+export default handler;

--- a/src/pages/courses/[id].js
+++ b/src/pages/courses/[id].js
@@ -1,0 +1,70 @@
+import AppLayout from "components/AppLayout.jsx";
+import CourseInstancesCard from "components/CourseInstancesCard.jsx";
+import ScoresByTermChart from "components/ScoresByTermChart.jsx";
+import Course from "models/Course";
+import "models/StudentOutcome";
+import { getSession } from "next-auth/client";
+import Head from "next/head";
+import Link from "next/link";
+import { Col, Row } from "react-bootstrap";
+import Breadcrumb from "react-bootstrap/Breadcrumb";
+import { useProtectPage } from "utils/auth";
+
+export default function CoursePage({ course }) {
+  const session = useProtectPage();
+  if (!session) return null;
+
+  return (
+    <>
+      <Head>
+        <title>
+          CPSC {course.number} – {course.title}
+        </title>
+      </Head>
+      <AppLayout>
+        <Breadcrumb>
+          <Breadcrumb.Item href="/courses" linkAs={Link}>
+            Courses
+          </Breadcrumb.Item>
+          <Breadcrumb.Item active>{course.title}</Breadcrumb.Item>
+        </Breadcrumb>
+
+        <h1 className="h3">
+          <span className="text-muted">CPSC {course.number}</span>{" "}
+          {course.title}
+        </h1>
+
+        <ScoresByTermChart className="mt-3" />
+
+        <Row>
+          <Col lg={6}>
+            <CourseInstancesCard course={course} />
+          </Col>
+        </Row>
+      </AppLayout>
+    </>
+  );
+}
+
+export async function getServerSideProps(context) {
+  const session = await getSession(context);
+  if (!session) return { props: {} };
+
+  const {
+    params: { id: courseId },
+  } = context;
+
+  let course;
+  try {
+    course = await Course.findOne({ _id: courseId })
+      .populate("studentOutcomes", "number definition")
+      .lean();
+  } catch {
+    course = null;
+  }
+
+  if (!course) return { notFound: true };
+
+  course = JSON.parse(JSON.stringify(course));
+  return { props: { course } };
+}

--- a/src/utils/email.js
+++ b/src/utils/email.js
@@ -1,4 +1,5 @@
 import * as sendGrid from "@sendgrid/mail";
+import { capitalize } from "./string";
 import User from "../models/User";
 
 const unsubscribeId = 14692;
@@ -12,10 +13,6 @@ const templateIds = {
   userAccessChange: "d-9ec83ef57e52483187663999580ae97a",
   registrationRequestUpdate: "d-dcad74638f37429e951ee7d1e92c284d",
 };
-
-function capitalize(str) {
-  return str.charAt(0).toUpperCase() + str.slice(1);
-}
 
 function createResetUrl(token) {
   return encodeURI(`${process.env.APP_URL}/reset_password?token=${token}`);

--- a/src/utils/string.js
+++ b/src/utils/string.js
@@ -1,0 +1,3 @@
+export function capitalize(str) {
+  return str.charAt(0).toUpperCase() + str.slice(1);
+}


### PR DESCRIPTION
Adds a course detail page accessible from the Course List page. The course is fetched server-side so that the title can be correctly populated. Then the course instances are fetched async.

The server-side fetching requires some additional logic. If the user is not authenticated, we return early with empty props. That way, the database is _not_ queried, since it might leak sensitive details. We then handle the client-side unauthorized redirect using the protect page hook.