### PR TITLE
Instructor access

### DIFF
--- a/seeders/registrationrequests.seeder.js
+++ b/seeders/registrationrequests.seeder.js
@@ -1,6 +1,7 @@
 import { Seeder } from "mongoose-data-seed";
 import RegistrationRequest from "../src/models/RegistrationRequest";
 import { hashPassword } from "../src/utils/auth";
+import { fakeTimestamps } from "../src/utils/faker";
 
 const data = [
   {
@@ -58,6 +59,7 @@ class RegistrationrequestsSeeder extends Seeder {
         return RegistrationRequest.collection.insertOne({
           ...registrationRequest,
           password: await hashPassword(registrationRequest.password),
+          ...fakeTimestamps(),
         });
       })
     );

--- a/seeders/users.seeder.js
+++ b/seeders/users.seeder.js
@@ -1,6 +1,7 @@
 import { Seeder } from "mongoose-data-seed";
 import User from "../src/models/User";
-import { hashPassword, createExpirationDate } from "../src/utils/auth";
+import { createExpirationDate, hashPassword } from "../src/utils/auth";
+import { fakeTimestamps } from "../src/utils/faker";
 
 const data = [
   {
@@ -56,6 +57,7 @@ class UsersSeeder extends Seeder {
         return User.collection.insertOne({
           ...user,
           password: await hashPassword(user.password),
+          ...fakeTimestamps(),
         });
       })
     );

--- a/seeders/users.seeder.js
+++ b/seeders/users.seeder.js
@@ -1,4 +1,5 @@
 import { Seeder } from "mongoose-data-seed";
+import Instructor from "../src/models/Instructor";
 import User from "../src/models/User";
 import { createExpirationDate, hashPassword } from "../src/utils/auth";
 import { fakeTimestamps } from "../src/utils/faker";
@@ -54,9 +55,15 @@ class UsersSeeder extends Seeder {
   async run() {
     return Promise.all(
       data.map(async (user) => {
+        let instructor = null;
+        if (user.accessLevel === "instructor") {
+          instructor = await Instructor.aggregate([{ $sample: { size: 1 } }]);
+          instructor = instructor[0]._id;
+        }
         return User.collection.insertOne({
           ...user,
           password: await hashPassword(user.password),
+          instructor,
           ...fakeTimestamps(),
         });
       })

--- a/src/components/UsersCard.js
+++ b/src/components/UsersCard.js
@@ -16,6 +16,7 @@ export default function UsersCard() {
           <tr>
             <th>Access Level</th>
             <th>Email</th>
+            <th>Instructor</th>
             <th>Created On</th>
             <th></th>
           </tr>
@@ -42,13 +43,17 @@ function UserRows() {
 
 function UserRow({ model }) {
   const [accessLevel, setAccessLevel] = useState(model.accessLevel);
+  const [instructor, setInstructor] = useState(model.instructor);
   const isRevoked = model.accessLevel === "revoked";
 
-  const changeAccessLevel = async () => {
+  const accessLevelChanged = accessLevel !== model.accessLevel;
+  const instructorChanged = instructor !== model.instructor;
+
+  const changeAccess = async () => {
     await fetch(`${USERS_PATH}/${model._id}`, {
       method: "PATCH",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ accessLevel }),
+      body: JSON.stringify({ accessLevel, instructor }),
     });
     mutate(USERS_PATH);
   };
@@ -69,18 +74,51 @@ function UserRow({ model }) {
         </Form.Control>
       </td>
       <td>{model.email}</td>
+      <td>
+        <InstructorSelect
+          defaultValue={instructor}
+          onChange={(event) => setInstructor(event.target.value || null)}
+        />
+      </td>
       <td>{formatTimestamp(model.createdAt)}</td>
       <td className="text-right">
         <Button
-          onClick={changeAccessLevel}
+          onClick={changeAccess}
           size="sm"
           variant="primary"
           className="ml-3"
-          disabled={accessLevel === model.accessLevel}
+          disabled={!accessLevelChanged && !instructorChanged}
         >
-          Update Access Level
+          Update Access
         </Button>
       </td>
     </tr>
+  );
+}
+
+function InstructorSelect({ defaultValue, onChange }) {
+  const { data } = useSWR("/api/instructors", fetcher);
+  if (!data) return null;
+
+  return (
+    <Form.Control
+      as="select"
+      size="sm"
+      custom
+      defaultValue={defaultValue}
+      onChange={onChange}
+    >
+      <option></option>
+      {data.map((instructor) => {
+        const {
+          _id,
+          name: { first: firstName, last: lastName },
+        } = instructor;
+
+        return (
+          <option key={_id} value={_id}>{`${firstName} ${lastName}`}</option>
+        );
+      })}
+    </Form.Control>
   );
 }

--- a/src/components/UsersCard.js
+++ b/src/components/UsersCard.js
@@ -80,6 +80,7 @@ function UserRow({ model }) {
       <td>
         <InstructorSelect
           defaultValue={instructor}
+          accessLevel={accessLevel}
           onChange={(event) => setInstructor(event.target.value || null)}
         />
       </td>
@@ -99,7 +100,7 @@ function UserRow({ model }) {
   );
 }
 
-function InstructorSelect({ defaultValue, onChange }) {
+function InstructorSelect({ defaultValue, onChange, accessLevel }) {
   const { data } = useSWR("/api/instructors", fetcher);
   if (!data) return null;
 
@@ -110,6 +111,7 @@ function InstructorSelect({ defaultValue, onChange }) {
       custom
       defaultValue={defaultValue}
       onChange={onChange}
+      disabled={accessLevel === "revoked"}
     >
       <option></option>
       {data.map((instructor) => {

--- a/src/components/UsersCard.js
+++ b/src/components/UsersCard.js
@@ -53,7 +53,10 @@ function UserRow({ model }) {
     await fetch(`${USERS_PATH}/${model._id}`, {
       method: "PATCH",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ accessLevel, instructor }),
+      body: JSON.stringify({
+        accessLevel: accessLevelChanged && accessLevel,
+        instructor,
+      }),
     });
     mutate(USERS_PATH);
   };

--- a/src/models/User.js
+++ b/src/models/User.js
@@ -28,6 +28,10 @@ const UserSchema = new Schema(
       token: { type: String, default: null },
       expiration: { type: Date, default: null },
     },
+    instructor: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: "Instructor",
+    },
   },
   { timestamps: true }
 );

--- a/src/pages/api/users/[id].js
+++ b/src/pages/api/users/[id].js
@@ -15,7 +15,10 @@ handler.patch(async (req, res) => {
     body: { accessLevel, instructor: instructorId },
   } = req;
 
-  if (!["instructor", "admin", "revoked"].includes(accessLevel)) {
+  if (
+    accessLevel &&
+    !["instructor", "admin", "revoked"].includes(accessLevel)
+  ) {
     return res.status(422).json({
       error: true,
       message: `"${accessLevel}" is not a valid access level`,
@@ -23,14 +26,15 @@ handler.patch(async (req, res) => {
   }
 
   try {
-    let instructor = null;
-    if (instructorId) {
-      instructor = await Instructor.findOne({ _id: instructorId });
+    const instructor = await Instructor.findOne({ _id: instructorId });
+    let changes = { instructor };
+    if (accessLevel) {
+      changes = { ...changes, accessLevel };
     }
 
     const updatedUser = await User.findOneAndUpdate(
       { _id: id, accessLevel: { $ne: "root" } },
-      { accessLevel, instructor },
+      changes,
       { new: true }
     )
       .select({ password: 0 })

--- a/src/pages/api/users/[id].js
+++ b/src/pages/api/users/[id].js
@@ -1,4 +1,5 @@
 import middleware from "middleware";
+import Instructor from "models/Instructor";
 import User from "models/User";
 import nextConnect from "next-connect";
 import { authenticate, forbiddenUnlessRoot } from "utils/auth";
@@ -11,7 +12,7 @@ handler.use(forbiddenUnlessRoot);
 handler.patch(async (req, res) => {
   const {
     query: { id },
-    body: { accessLevel },
+    body: { accessLevel, instructor: instructorId },
   } = req;
 
   if (!["instructor", "admin", "revoked"].includes(accessLevel)) {
@@ -22,9 +23,14 @@ handler.patch(async (req, res) => {
   }
 
   try {
+    let instructor = null;
+    if (instructorId) {
+      instructor = await Instructor.findOne({ _id: instructorId });
+    }
+
     const updatedUser = await User.findOneAndUpdate(
       { _id: id, accessLevel: { $ne: "root" } },
-      { accessLevel },
+      { accessLevel, instructor },
       { new: true }
     )
       .select({ password: 0 })

--- a/src/utils/faker.js
+++ b/src/utils/faker.js
@@ -1,0 +1,8 @@
+import faker from "faker";
+
+export function fakeTimestamps() {
+  const createdAt = faker.date.recent();
+  const updatedAt = faker.date.between(createdAt, new Date());
+
+  return { createdAt, updatedAt };
+}


### PR DESCRIPTION
This changes adds the ability for a root user to give users access to instructor records. I left it as a "has one" relation for now, since that simplifies the model and UI. That was after trying a handful of multi-select plugins and not finding anything that fit what we needed. So for now, keeping it to spec with a user having access to a single instructor.

One notable challenge was the access change email. It gets sent whenever the access level is being set, _even if the value did not change._ So I had to jump through a few hoops to avoid setting that value unless it was actually changing. 

One awesome thing that worked out was the async instructor fetch for the select dropdown. SWR automatically ensures only a single fetch call is made to the API, so the results were then shared across all the dropdown components.